### PR TITLE
feat: add opening hours section with responsive design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a static website for Brunfelsia Roastery (brunfelsia.jp), a specialty coffee roasting company operated by Paddle&Brew 株式会社.
+
+## Development Commands
+
+This is a pure static site with no build process:
+- **Local development**: Open `index.html` directly in a browser or use a local server (e.g., `python3 -m http.server`)
+- **Deployment**: Push to GitHub (configured for GitHub Pages with CNAME)
+
+## Architecture
+
+Simple static site structure:
+- `index.html` - Single-page application with sections: About, Scene, Promise, Company, Contact
+- `styles.css` - All styling including responsive design and animations
+- `script.js` - Handles all interactivity:
+  - Smooth scroll navigation with section targeting
+  - Hamburger menu for mobile with body scroll lock
+  - Image slideshow (5-second rotation)
+  - Intersection Observer for fade-in animations
+  - Contact form validation (uses Formspree endpoint: movjqwov)
+  - Badge ticker animation with dynamic speed calculation
+
+## Key Implementation Details
+
+- **No external dependencies** - Pure vanilla JavaScript, HTML5, CSS3
+- **Responsive breakpoint**: 768px for mobile menu
+- **Animation timing**: 
+  - Hero fade-in: 1s ease-out
+  - Section fade-in: 0.6s ease-out with 0.1 threshold
+  - Image slideshow: 5s interval
+- **Form handling**: Formspree integration, requires both email and message fields
+- **Performance optimizations**: Debounced resize handlers, requestAnimationFrame for scroll animations

--- a/index.html
+++ b/index.html
@@ -97,12 +97,32 @@
                     <h2>Paddle&Brew 株式会社</h2>
                     <div class="company-info">
                         <div class="office-info">
-                            <h3>Head Office</h3>
+                            <h3>HEAD OFFICE</h3>
                             <p>〒154-0001 東京都世田谷区池尻 2-35-9 703</p>
                         </div>
                         <div class="office-info">
-                            <h3>Roastery</h3>
+                            <h3>ROASTERY</h3>
                             <p>〒227-0038 神奈川県横浜市青葉区奈良 1-22-8 garage, 1F</p>
+                        </div>
+                        <div class="opening-hours">
+                            <h3>ROASTERY OPEN</h3>
+                            <div class="hours-content">
+                                <p class="hours-note">In principle,</p>
+                                <div class="hours-grid">
+                                    <div class="hours-item">
+                                        <span class="day">WEEK DAY</span>
+                                        <span class="time">ASK</span>
+                                    </div>
+                                    <div class="hours-item">
+                                        <span class="day">SAT</span>
+                                        <span class="time">14:00-18:00<span class="note">(normally)</span></span>
+                                    </div>
+                                    <div class="hours-item">
+                                        <span class="day">SUN</span>
+                                        <span class="time">11:00-18:00</span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -325,7 +325,7 @@ footer {
 
 @media (max-width: 767px) {
     .image-mask {
-        padding-top: 56.25%; /* スマホサイズでは16:9のアスクト比に変更 */
+        padding-top: 56.25%; /* スマホサイズでは16:9のアスペクト比に変更 */
     }
 }
 
@@ -709,7 +709,7 @@ footer p {
 @media (min-width: 768px) {
     .company-content {
         flex-direction: row;
-        align-items: flex-start; /* 上寄せに変更 */
+        align-items: stretch; /* ストレッチに変更して高さを揃える */
         gap: 2rem;
     }
 
@@ -722,11 +722,26 @@ footer p {
         flex: 1;
         height: auto;
         padding-bottom: 0;
+        display: flex;
+        align-items: center; /* 画像を中央に配置 */
     }
 
     .company-section .image-mask {
         position: relative;
-        padding-top: 75%;
+        width: 100%;
+        height: 100%;
+        min-height: 300px; /* 最小高さを設定 */
+        overflow: hidden;
+    }
+    
+    .company-section .company-image {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
     }
 }
 
@@ -1033,7 +1048,9 @@ form::after {
         margin-bottom: 0;
     }
 
-    /* 既存のスタイル... */
+    .company-info {
+        margin-bottom: 2rem; /* スマホサイズでの下マージンを追加 */
+    }
 }
 
 /* 初期状態で要素を非表示に */
@@ -1098,5 +1115,142 @@ form::after {
     to {
         opacity: 1;
         transform: scale(1);
+    }
+}
+
+.opening-hours p {
+    margin: 0.2em 0; /* 基本の上下マージン */
+}
+
+.opening-hours {
+    margin-top: 3em;
+}
+
+.opening-hours h3 {
+    margin-bottom: 0.1em;
+}
+
+.opening-hours p:first-of-type {
+    color: rgba(0, 0, 0, 0.3); /* 黒で、不透明度をちょっと下げて */
+}
+
+@media screen and (max-width: 768px) {
+    .company-info {
+        margin-bottom: 2rem;
+    }
+}
+
+.office-info h3 {
+    margin-bottom: 0.1rem;  /* もしくは8px */
+}
+
+.office-info p {
+    margin-top: 0.1rem;  /* もしくは8px */
+}
+
+/* Opening Hours Styles */
+.opening-hours {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.opening-hours h3 {
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+}
+
+.hours-content {
+    margin-top: 0.5rem;
+}
+
+.hours-note {
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+    color: rgba(0, 0, 0, 0.7);
+    font-style: italic;
+}
+
+.hours-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.hours-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.hours-item:last-child {
+    border-bottom: none;
+}
+
+.hours-item .day {
+    font-weight: 600;
+    font-size: 0.95rem;
+    flex: 0 0 40%;
+}
+
+.hours-item .time {
+    text-align: right;
+    font-size: 0.95rem;
+    flex: 1;
+}
+
+.hours-item .note {
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.6);
+    margin-left: 0.3rem;
+}
+
+/* PC Styles for Opening Hours */
+@media (min-width: 768px) {
+    .opening-hours {
+        max-width: 400px;
+    }
+    
+    .hours-grid {
+        gap: 1rem;
+    }
+    
+    .hours-item {
+        padding: 0.7rem 0;
+    }
+}
+
+/* Mobile Styles for Opening Hours */
+@media (max-width: 767px) {
+    .opening-hours {
+        margin-top: 1.5rem;
+        padding: 1rem 2rem;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+    }
+    
+    .opening-hours h3 {
+        font-size: 1rem;
+    }
+    
+    .hours-item .day {
+        font-size: 0.9rem;
+    }
+    
+    .hours-item .time {
+        font-size: 0.9rem;
+    }
+    
+    .hours-item .note {
+        display: block;
+        margin-left: 0;
+        margin-top: 0.2rem;
     }
 }


### PR DESCRIPTION
## Summary
- Added structured opening hours display to company section with modern grid layout
- Implemented fully responsive design that maintains consistent padding across mobile and PC views
- Fixed PC image alignment issue to match text section height using flexbox

## Changes
- **HTML**: Added opening hours section with semantic structure
- **CSS**: Implemented responsive styles with proper mobile/PC breakpoints
- **Documentation**: Added CLAUDE.md for repository guidance

## Test plan
- [x] Test mobile view (< 768px) - consistent padding with other sections
- [x] Test PC view (>= 768px) - image height matches text section
- [x] Verify opening hours display correctly on both sizes
- [x] Check all existing functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)