### PR TITLE
feat: ポートフォリオセクションを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a pure static site with no build process:
 
 Simple static site structure:
 - `index.html` - Single-page application with sections: About, Scene, Promise, Company, Contact
-- `styles.css` - All styling including responsive design and animations
+- `styles.css` - All styling including responsive design and animations (1255 lines)
 - `script.js` - Handles all interactivity:
   - Smooth scroll navigation with section targeting
   - Hamburger menu for mobile with body scroll lock
@@ -24,6 +24,11 @@ Simple static site structure:
   - Intersection Observer for fade-in animations
   - Contact form validation (uses Formspree endpoint: movjqwov)
   - Badge ticker animation with dynamic speed calculation
+  - Dynamic hero container height adjustment (window.innerHeight)
+  - Click-outside-menu functionality
+- `assets/` - Static resources:
+  - `images/` - Logo, backgrounds, and slideshow images (kv_*.jpg series)
+  - `videos/` - kv.mp4 (currently unused)
 
 ## Key Implementation Details
 
@@ -31,7 +36,14 @@ Simple static site structure:
 - **Responsive breakpoint**: 768px for mobile menu
 - **Animation timing**: 
   - Hero fade-in: 1s ease-out
-  - Section fade-in: 0.6s ease-out with 0.1 threshold
+  - Section fade-in: 0.6s ease-out with 0.1 threshold (100ms delay for performance)
   - Image slideshow: 5s interval
-- **Form handling**: Formspree integration, requires both email and message fields
-- **Performance optimizations**: Debounced resize handlers, requestAnimationFrame for scroll animations
+  - Badge ticker: Dynamic speed based on text width (width/50)
+- **Form handling**: Formspree integration (endpoint: movjqwov), requires both email and message fields
+- **Performance optimizations**: 
+  - Debounced resize handlers (250ms delay)
+  - requestAnimationFrame for scroll animations
+  - Intersection Observers unobserved after triggering
+  - trackVisibility option for better performance
+- **CSS Architecture**: Uses CSS custom properties (--main-bg-color, --main-bg-image) for theming
+- **Contact endpoints**: Phone: 03-6450-7667, Email: vhan@brunfelsia.jp

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
                     <li><a href="#about">About us</a></li>
                     <li><a href="#scene">Scene</a></li>
                     <li><a href="#promise">We promise</a></li>
+                    <li><a href="#portfolio">Portfolio</a></li>
                     <li><a href="#company">Company</a></li>
                     <li><a href="#contact">Contact</a></li>
                 </ul>
@@ -91,6 +92,34 @@
                 </div>
             </div>
         </section>
+        
+        <!-- Portfolio Section -->
+        <section id="portfolio" class="portfolio-section">
+            <div class="portfolio-content">
+                <h2>Portfolio</h2>
+                <p class="portfolio-intro">BRUNFELSIA ROASTERYでは、これまで下記の企業様へ卸販売およびオリジナルブレンドのご提供を行ってまいりました。今後も多彩な業務提携を通じて、各社様のブランド価値向上に貢献してまいります。</p>
+                
+                <div class="portfolio-list">
+                    <h3>企業様向けオリジナルブレンド制作実績</h3>
+                    <div class="company-list">
+                        <div class="company-item">NORTHVILLAGE</div>
+                        <div class="company-item">御殿場高原 源泉 茶目湯殿</div>
+                        <div class="company-item">REEBOK</div>
+                        <div class="company-item">AUDI JAPAN</div>
+                        <div class="company-item">BURTON</div>
+                        <div class="company-item">MASERATI</div>
+                        <div class="company-item">会員制レストラン「MoDeRiTIOn」</div>
+                        <div class="company-item">SUBARU</div>
+                        <div class="company-item">Volkswagen</div>
+                        <div class="company-item">PLOTTER</div>
+                        <div class="company-item">他多数</div>
+                    </div>
+                </div>
+                
+                <p class="portfolio-footer">上記以外にも、各種イベントやカフェ、レストラン様、著名人とのコラボレーション実績が多数ございます。<br>ご要望に応じて、業態やシーンに最適なコーヒーをご提案いたしますので、お気軽にお問い合わせください。</p>
+            </div>
+        </section>
+        
         <section id="company" class="company-section">
             <div class="company-content">
                 <div class="text-section">

--- a/styles.css
+++ b/styles.css
@@ -1254,3 +1254,114 @@ form::after {
         margin-top: 0.2rem;
     }
 }
+
+/* Portfolio Section Styles */
+.portfolio-section {
+    padding: 5rem 2rem;
+    color: black;
+}
+
+.portfolio-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.portfolio-section h2 {
+    text-align: center;
+    font-size: 36px;
+    margin-bottom: 3rem;
+}
+
+.portfolio-intro {
+    font-size: 16px;
+    line-height: 1.6;
+    margin-bottom: 3rem;
+    text-align: center;
+}
+
+.portfolio-list {
+    margin: 2rem 0;
+    padding: 2rem;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.portfolio-list h3 {
+    margin-bottom: 1.5rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-align: center;
+}
+
+.company-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.company-item {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+.company-item:last-child {
+    border-bottom: none;
+}
+
+.portfolio-footer {
+    font-size: 16px;
+    line-height: 1.6;
+    margin-top: 3rem;
+    text-align: center;
+}
+
+/* PC Styles for Portfolio */
+@media (min-width: 768px) {
+    .portfolio-list {
+        margin: 2rem 0;
+    }
+}
+
+/* Mobile Styles for Portfolio */
+@media (max-width: 767px) {
+    .portfolio-section {
+        padding: 5rem 0 0 0;
+    }
+    
+    .portfolio-content {
+        padding: 0;
+    }
+    
+    .portfolio-section h2 {
+        font-size: 24px;
+        margin-bottom: 2rem;
+        text-align: left;
+    }
+    
+    .portfolio-intro,
+    .portfolio-footer {
+        text-align: left;
+    }
+    
+    .portfolio-list {
+        margin: 1.5rem 0;
+        padding: 1rem 2rem;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+    }
+    
+    .portfolio-list h3 {
+        font-size: 1rem;
+        text-align: left;
+    }
+    
+    .company-item {
+        text-align: left;
+        font-size: 0.9rem;
+    }
+}


### PR DESCRIPTION
## 概要
Promiseセクションの後に新しいポートフォリオセクションを追加しました。

## 変更内容
- 企業様向けオリジナルブレンド制作実績を掲載する新セクションを追加
- NORTHVILLAGE、REEBOK、AUDI JAPAN、BURTON、MASERATIなど複数の企業実績を表示
- Roastery Openセクションと同様の背景スタイル（薄い背景色とボーダー）を適用
- PC・スマホ両サイズで他セクションと統一されたマージンを設定
- ナビゲーションメニューにPortfolioリンクを追加

## テストプラン
- [ ] PCサイズでPromiseセクションと同じ幅（max-width: 800px）で表示されることを確認
- [ ] スマホサイズで他のセクションと同じマージンで表示されることを確認
- [ ] ナビゲーションリンクからスムーズスクロールでポートフォリオセクションに移動できることを確認
- [ ] フェードインアニメーションが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)